### PR TITLE
Add support for setting GOARM

### DIFF
--- a/lib/packager/compile_target.rb
+++ b/lib/packager/compile_target.rb
@@ -2,12 +2,13 @@ require "openssl"
 
 class Packager
   class CompileTarget
-    attr_accessor :os, :arch, :name
+    attr_accessor :os, :arch, :arm, :name
 
     def initialize(name, version, props, workdir, defaults={}, flagsmap={})
       @name = name
       @os = props["os"]
       @arch = props["arch"]
+      @arm = props["arm"]
       @workdir = workdir
 
       props = defaults.merge(props)
@@ -65,6 +66,7 @@ class Packager
 
       ENV["GOOS"] = @os.to_s
       ENV["GOARCH"] = @arch.to_s
+      ENV["GOARM"] = @arm.to_s if @arm
 
       @env.each do |k, v|
         ENV[k] = v
@@ -126,6 +128,9 @@ class Packager
 
       out.gsub!("{{arch}}", @arch.to_s.downcase)
       out.gsub!("{{ARCH}}", @arch.to_s.upcase)
+
+      out.gsub!("{{arm}}", @arm.to_s.downcase)
+      out.gsub!("{{ARM}}", @arm.to_s.upcase)
 
       out.gsub!("{{sha}}", sha)
       out.gsub!("{{SHA}}", sha.upcase)


### PR DESCRIPTION
While tweaking choria building system to build ARM Debian packages, I ended with an ARMv5 binary:
```
% file choria-0.14.0-linux-arm
choria-0.14.0-linux-arm: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, BuildID[md5/uuid]=c123c1f49956264ff8390b339cdaf834, not stripped
```

Setting `GOARM` should allow targeting a specific ARM version.

When building with `GOARCH=arm`, `GOARM` can be used to target a specified ARM architecture as referenced in the go documentation:
https://github.com/golang/go/wiki/GoArm

This change is expected to allow setting ARM version when building go-choria with a fragment like such:
```yaml
foss:
  compile_targets:
    arm_linux:
      output: choria-{{version}}-{{os}}-{{arch}}v{{arm}}
      os: linux
      arch: arm
      arm: 7
```

Unfortunately, I could not test this change (I am really not in docker) so mindful proofreading is advised :confused: 