### PR TITLE
Workaround bug around copy_file_range syscall

### DIFF
--- a/lib/packager/package.rb
+++ b/lib/packager/package.rb
@@ -86,6 +86,10 @@ class Packager
       if File.exist?(binary)
         puts "  >>> copying binary %s => %s" % [compile_target.output, workdir]
 
+        # Workaround a bug introduced in version 5.6.0 of the Linux kernel
+        # https://github.com/docker/for-linux/issues/1015
+        FileUtils.touch(binary)
+
         FileUtils.cp(binary, workdir)
       end
     end


### PR DESCRIPTION
When building Debian packages on Debian Bullseye, the generated .deb
file does not contain the /usr/bin/choria binary, but an empty file.

This is caused by a bug introducted in Linux 5.6.0 and still present in
5.10.0 shipped with Debian Bullseye where the copy_file_range syscall
can have an unexpected behaviour.

The problem is tracked here:
https://github.com/docker/for-linux/issues/1015

Introduce a workaround that allows to build Debian packages with a
recent Debian host.
