### PR TITLE
fix install on bullseye

### DIFF
--- a/install-choria.sh
+++ b/install-choria.sh
@@ -24,7 +24,7 @@ case "${FLAVOUR?}" in
     ;;
 
   bullseye_64)
-    wget -O /tmp/puppet.deb http://apt.puppetlabs.com/puppet7-release-buster.deb
+    wget -O /tmp/puppet.deb http://apt.puppetlabs.com/puppet7-release-bullseye.deb
 
     ;;
 


### PR DESCRIPTION
Hi,

It seems there is a copy/paste issue on the bulleyes case of `install-choria.sh`, so here is a quick PR to fix that.

Regards,