### PR TITLE
remove dh-systemd package from apt install cmd, as it no longer exists

### DIFF
--- a/Dockerfile.jammy-go
+++ b/Dockerfile.jammy-go
@@ -10,8 +10,7 @@ RUN apt-get update && apt-get install -y \
     ruby \
     rake \
     debhelper \
-    git \
-    dh-systemd
+    git
 
 RUN wget -q https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GOVERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
this should fix the issue after the merge of https://github.com/choria-io/packager/pull/50